### PR TITLE
Fix: vercel does not serve login route

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
Add fix so that regardless the path the user requests, it always serves /index.html